### PR TITLE
Add find_device function for utilize Device trait

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,23 +1,33 @@
 use crate::bus::Device;
+use log::error;
+
+pub enum Permission {
+    Normal,
+    ReadOnly,
+    Invalid,
+}
 
 pub struct Memory {
     base: usize,
     memory: Vec<u8>,
+    permission: Permission,
 }
 
 impl Memory {
-    pub fn new(base: usize, binary: Vec<u8>) -> Self {
+    pub fn new(base: usize, binary: Vec<u8>, perm: Permission) -> Self {
         Self {
             base: base,
-            memory: binary.clone()
+            memory: binary.clone(),
+            permission: perm,
         }
     }
 
-    pub fn new_empty(base: usize, size: usize) -> Self {
+    pub fn new_empty(base: usize, size: usize, perm: Permission) -> Self {
         let memory = vec![0; size];
         Self {
             base: base,
             memory: memory,
+            permission: perm,
         }
     }
 
@@ -25,21 +35,40 @@ impl Memory {
 
 impl Device for Memory {
     fn load(&self, addr: u16) -> Result<u8, ()> {
-        let addr = (addr as usize) - self.base;
-        match self.memory.get(addr) {
-            Some(elem) => Ok(*elem),
-            None => Err(()),
+        match self.permission {
+            Permission::Normal | Permission::ReadOnly => {
+                let addr = (addr as usize) - self.base;
+                match self.memory.get(addr) {
+                    Some(elem) => Ok(*elem),
+                    None => Err(()),
+                }
+            },
+            Permission::Invalid => {
+                info!("Invalid load on address {:#X}", addr);
+                Ok(0)
+            },
         }
     }
 
     fn store(&mut self, addr: u16, value: u8) -> Result<(), ()> {
-        let addr = (addr as usize) - self.base;
-        match self.memory.get_mut(addr) {
-            Some(elem) => {
-                *elem = value;
+        match self.permission {
+            Permission::Normal => {
+                let addr = (addr as usize) - self.base;
+                match self.memory.get_mut(addr) {
+                    Some(elem) => {
+                        *elem = value;
+                        Ok(())
+                    },
+                    None => Err(()),
+                }
+            },
+            Permission::ReadOnly => {
                 Ok(())
             },
-            None => Err(()),
+            Permission::Invalid => {
+                info!("Invalid store to address {:#X}", addr);
+                Ok(())
+            },
         }
     }
 }


### PR DESCRIPTION
Use "find_device" and "find_device_mut" functions which return a
implemented "Device" trait. Therefore we can reach load/store utility
with a single function call calling by the returned trait.