### PR TITLE
Refactor storage devices into a vector

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5,7 +5,7 @@ use crate::joypad::{Joypad, JOYPAD_ADDR};
 
 use num_traits::FromPrimitive;
 use num_derive::FromPrimitive;
-use log::{error, info, debug};
+use log::{error, info};
 
 /// memory map of LR35902, xxx_START to xxx_END inclusive
 const CATRIDGE_START: u16 = 0x0000;
@@ -164,20 +164,13 @@ impl Bus {
     }
 
     fn find_storage(&self, addr: u16) -> Option<&Box<dyn Device>> {
-        let matched: Vec<&Box<dyn Device>> = self.storage
-                                                .iter()
-                                                .filter(|dev| {
-                                                    let (start, end) = dev.range();
-                                                    start <= addr && addr <= end
-                                                }).collect();
-        match matched.len() {
-            0 => return None,
-            1 => return Some(matched[0]),
-            _ => {
-                error!("Multiple device defined on address {:#X}", addr);
-                std::process::exit(1);
-            },
+        for dev in self.storage.iter() {
+            let (start, end) = dev.range();
+            if start <= addr && addr <= end {
+                return Some(dev);
+            }
         }
+        None
     }
 
     fn find_device(&self, addr: u16) -> Option<&dyn Device> {
@@ -225,22 +218,13 @@ impl Bus {
     }
 
     fn find_storage_mut(&mut self, addr: u16) -> Option<&mut Box<dyn Device>> {
-        let mut matched: Vec<&mut Box<dyn Device>> = self.storage
-                                                .iter_mut()
-                                                .filter(|dev| {
-                                                    let (start, end) = dev.range();
-                                                    start <= addr && addr <= end
-                                                }).collect();
-        match matched.len() {
-            0 => None,
-            1 => {
-                Some(matched.pop().unwrap())
-            },
-            _ => {
-                error!("Multiple device defined on address {:#X}", addr);
-                std::process::exit(1);
-            },
+        for dev in self.storage.iter_mut() {
+            let (start, end) = dev.range();
+            if start <= addr && addr <= end {
+                return Some(dev);
+            }
         }
+        None
     }
 
     fn find_device_mut(&mut self, addr: u16) -> Option<&mut dyn Device> {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -122,7 +122,7 @@ enum IO {
 pub trait Device {
     fn load(&self, addr: u16) -> Result<u8, ()>;
     fn store(&mut self, addr: u16, value: u8) -> Result<(), ()>;
-    fn range(&self) -> (u16, u16);
+    fn is_contain(&self, addr: u16) -> bool;
 }
 
 pub struct Bus {
@@ -165,8 +165,7 @@ impl Bus {
 
     fn find_storage(&self, addr: u16) -> Option<&Box<dyn Device>> {
         for dev in self.storage.iter() {
-            let (start, end) = dev.range();
-            if start <= addr && addr <= end {
+            if dev.is_contain(addr) {
                 return Some(dev);
             }
         }
@@ -219,8 +218,7 @@ impl Bus {
 
     fn find_storage_mut(&mut self, addr: u16) -> Option<&mut Box<dyn Device>> {
         for dev in self.storage.iter_mut() {
-            let (start, end) = dev.range();
-            if start <= addr && addr <= end {
+            if dev.is_contain(addr) {
                 return Some(dev);
             }
         }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -333,7 +333,9 @@ impl Device for Gpu {
         }
     }
 
-    fn range(&self) -> (u16, u16) {
-        (0, 0)
+    fn is_contain(&self, addr: u16) -> bool {
+        // TODO: Transfer control of lcdc, scy, scx, etc. to gpu
+        // and share this interface with them.
+        false
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -332,4 +332,8 @@ impl Device for Gpu {
             _ => Err(()),
         }
     }
+
+    fn range(&self) -> (u16, u16) {
+        (0, 0)
+    }
 }

--- a/src/joypad.rs
+++ b/src/joypad.rs
@@ -68,4 +68,8 @@ impl Device for Joypad {
         self.mask = value;
         Ok(())
     }
+
+    fn range(&self) -> (u16, u16) {
+        (0, 0)
+    }
 }

--- a/src/joypad.rs
+++ b/src/joypad.rs
@@ -70,6 +70,6 @@ impl Device for Joypad {
     }
 
     fn range(&self) -> (u16, u16) {
-        (0, 0)
+        (JOYPAD_ADDR, JOYPAD_ADDR)
     }
 }

--- a/src/joypad.rs
+++ b/src/joypad.rs
@@ -69,7 +69,7 @@ impl Device for Joypad {
         Ok(())
     }
 
-    fn range(&self) -> (u16, u16) {
-        (JOYPAD_ADDR, JOYPAD_ADDR)
+    fn is_contain(&self, addr: u16) -> bool {
+        addr == JOYPAD_ADDR
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -75,9 +75,10 @@ impl Device for Memory {
             },
         }
     }
-    fn range(&self) -> (u16, u16) {
+
+    fn is_contain(&self, addr: u16) -> bool {
         let start = self.base as u16;
         let end = start + self.memory.len() as u16 - 1;
-        (start, end)
+        start <= addr && addr <= end
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -14,21 +14,25 @@ pub struct Memory {
 }
 
 impl Memory {
-    pub fn new(base: usize, binary: Vec<u8>, perm: Permission) -> Self {
-        Self {
-            base: base,
-            memory: binary.clone(),
-            permission: perm,
-        }
-    }
-
-    pub fn new_empty(base: usize, size: usize, perm: Permission) -> Self {
-        let memory = vec![0; size];
-        Self {
+    pub fn new(base: usize, size: usize, binary: Vec<u8>, perm: Permission) -> Box<Self> {
+        let mut memory = binary.clone();
+        let rest = size - memory.len();
+        let mut empty = vec![0; rest];
+        memory.append(&mut empty);
+        Box::new(Self {
             base: base,
             memory: memory,
             permission: perm,
-        }
+        })
+    }
+
+    pub fn new_empty(base: usize, size: usize, perm: Permission) -> Box<Self> {
+        let memory = vec![0; size];
+        Box::new(Self {
+            base: base,
+            memory: memory,
+            permission: perm,
+        })
     }
 
 }
@@ -70,5 +74,10 @@ impl Device for Memory {
                 Ok(())
             },
         }
+    }
+    fn range(&self) -> (u16, u16) {
+        let start = self.base as u16;
+        let end = start + self.memory.len() as u16 - 1;
+        (start, end)
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -129,7 +129,7 @@ impl Device for Timer {
         Ok(())
     }
 
-    fn range(&self) -> (u16, u16) {
-        (TIMER_START, TIMER_END)
+    fn is_contain(&self, addr :u16) -> bool {
+        TIMER_START <= addr && addr <= TIMER_END
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -128,4 +128,8 @@ impl Device for Timer {
         }
         Ok(())
     }
+
+    fn range(&self) -> (u16, u16) {
+        (0, 0)
+    }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -130,6 +130,6 @@ impl Device for Timer {
     }
 
     fn range(&self) -> (u16, u16) {
-        (0, 0)
+        (TIMER_START, TIMER_END)
     }
 }


### PR DESCRIPTION
Therefore, we can use find_storage to management them easily.
I am trying to refactor the devices which shared a same concept into a vector.
In my opinion, the following devices that can be refactor is those whom can be updated.